### PR TITLE
Adding Feature 1: View Staff List

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 
 /**
  * API of the Logic component
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of staff */
+    ObservableList<Staff> getFilteredStaffList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,11 +2,13 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ListType;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
@@ -51,4 +53,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Gets the ObjectProperty of list (person, staff, etc) that should be displayed now.
+     */
+    ObjectProperty<ListType> getCurrentListTypeProperty();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 import seedu.address.storage.Storage;
 
 /**
@@ -69,6 +70,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    @Override
+    public ObservableList<Staff> getFilteredStaffList() {
+        return model.getFilteredStaffList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -5,6 +5,8 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -13,6 +15,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ListType;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -30,6 +33,7 @@ public class LogicManager implements Logic {
 
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
+    private final ObjectProperty<ListType> currentListTypeProperty = new SimpleObjectProperty<>(ListType.PERSON);
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
@@ -41,6 +45,18 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
+
+        listTypeListener();
+    }
+
+    private void listTypeListener() {
+        model.getListTypeProperty().addListener(((observable, oldValue, newValue) -> {
+            currentListTypeProperty.set(newValue);
+        }));
+    }
+
+    public ObjectProperty<ListType> getCurrentListTypeProperty() {
+        return currentListTypeProperty;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddStaffCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStaffCommand.java
@@ -71,7 +71,7 @@ public class AddStaffCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.addPerson(toAdd);
+        model.addStaff(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListStaffCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListStaffCommand.java
@@ -5,6 +5,9 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STAFF;
 
 import seedu.address.model.Model;
 
+/**
+ * Lists all staff in the address book to the user.
+ */
 public class ListStaffCommand extends Command {
 
     public static final String COMMAND_WORD = "list_staff";

--- a/src/main/java/seedu/address/logic/commands/ListStaffCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListStaffCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STAFF;
+
+import seedu.address.model.Model;
+
+public class ListStaffCommand extends Command {
+
+    public static final String COMMAND_WORD = "list_staff";
+
+    public static final String MESSAGE_SUCCESS = "Listed all staff";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredStaffList(PREDICATE_SHOW_ALL_STAFF);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListStaffCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ListStaffCommand.COMMAND_WORD:
+            return new ListStaffCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -123,7 +123,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setStaff(Staff target, Staff editedStaff) {
         requireNonNull(editedStaff);
-
         this.staff.setStaff(target, editedStaff);
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,7 +7,9 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.UniqueStaffList;
 
 /**
  * Wraps all data at the address-book level
@@ -16,6 +18,8 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+
+    private final UniqueStaffList staff;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,6 +30,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        staff = new UniqueStaffList();
     }
 
     public AddressBook() {}
@@ -49,12 +54,21 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the staff list with {@code staff}.
+     * {@code staff} must not contain duplicate persons.
+     */
+    public void setStaff(List<Staff> staff) {
+        this.staff.setStaffs(staff);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setStaff(newData.getStaffList());
     }
 
     //// person-level operations
@@ -68,11 +82,27 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a staff with the same identity as {@code staff} exists in the address book.
+     */
+    public boolean hasStaff(Staff staff) {
+        requireNonNull(staff);
+        return this.staff.contains(staff);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */
     public void addPerson(Person p) {
         persons.add(p);
+    }
+
+    /**
+     * Adds a staff to the address book.
+     * The staff must not already exist in the address book.
+     */
+    public void addPerson(Staff s) {
+        this.staff.add(s);
     }
 
     /**
@@ -87,11 +117,30 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the given staff {@code target} in the list with {@code editedStaff}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedStaff} must not be the same as another existing staff in the address book.
+     */
+    public void setStaff(Staff target, Staff editedStaff) {
+        requireNonNull(editedStaff);
+
+        this.staff.setStaff(target, editedStaff);
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeStaff(Staff key) {
+        this.staff.remove(key);
     }
 
     //// util methods
@@ -109,6 +158,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Staff> getStaffList() {
+        return this.staff.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
@@ -120,7 +174,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
 
         AddressBook otherAddressBook = (AddressBook) other;
-        return persons.equals(otherAddressBook.persons);
+        return persons.equals(otherAddressBook.persons) && staff.equals(otherAddressBook.staff);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -57,7 +57,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Replaces the contents of the staff list with {@code staff}.
      * {@code staff} must not contain duplicate persons.
      */
-    public void setStaff(List<Staff> staff) {
+    public void setStaffs(List<Staff> staff) {
         this.staff.setStaffs(staff);
     }
 
@@ -68,7 +68,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
-        setStaff(newData.getStaffList());
+        setStaffs(newData.getStaffList());
     }
 
     //// person-level operations
@@ -101,7 +101,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Adds a staff to the address book.
      * The staff must not already exist in the address book.
      */
-    public void addPerson(Staff s) {
+    public void addStaff(Staff s) {
         this.staff.add(s);
     }
 

--- a/src/main/java/seedu/address/model/ListType.java
+++ b/src/main/java/seedu/address/model/ListType.java
@@ -1,5 +1,8 @@
 package seedu.address.model;
 
+/**
+ * Represents the different types of lists that ResiConnect can display to the user.
+ */
 public enum ListType {
     PERSON, STAFF
 }

--- a/src/main/java/seedu/address/model/ListType.java
+++ b/src/main/java/seedu/address/model/ListType.java
@@ -1,0 +1,5 @@
+package seedu.address.model;
+
+public enum ListType {
+    PERSON, STAFF
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Staff;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Staff> PREDICATE_SHOW_ALL_STAFF = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -59,10 +60,21 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a staff with the same identity as {@code staff} exists in the address book.
+     */
+    boolean hasStaff(Staff staff);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
     void deletePerson(Person target);
+
+    /**
+     * Deletes the given staff.
+     * The staff must exist in the address book.
+     */
+    void deleteStaff(Staff target);
 
     /**
      * Adds the given person.
@@ -71,11 +83,24 @@ public interface Model {
     void addPerson(Person person);
 
     /**
+     * Adds the given staff.
+     * {@code staff} must not already exist in the address book.
+     */
+    void addStaff(Staff staff);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Replaces the given staff {@code target} with {@code editedStaff}.
+     * {@code target} must exist in the address book.
+     * The staff identity of {@code editedPerson} must not be the same as another existing staff in the address book.
+     */
+    void setStaff(Staff target, Staff editedStaff);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
@@ -119,4 +120,19 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredStaffList(Predicate<Staff> predicate);
+
+    /**
+     * Gets the ObjectProperty of list (person, staff, etc) that should be displayed now.
+     */
+    ObjectProperty<ListType> getListTypeProperty();
+
+    /**
+     * Gets the list type of the list that should be displayed now
+     */
+    ListType getListType();
+
+    /**
+     * Set the type of list (person, staff) to be displayed now
+     */
+    void setListType(ListType listType);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 
 /**
  * The API of the Model component.
@@ -84,4 +85,13 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /** Returns an unmodifiable view of the filtered staff list */
+    ObservableList<Staff> getFilteredStaffList();
+
+    /**
+     * Updates the filter of the filtered staff list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredStaffList(Predicate<Staff> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -125,6 +125,7 @@ public class ModelManager implements Model {
         addressBook.removeStaff(target);
     }
 
+    @Override
     public void addStaff(Staff staff) {
         addressBook.addStaff(staff);
         updateFilteredStaffList(PREDICATE_SHOW_ALL_STAFF);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -137,7 +137,6 @@ public class ModelManager implements Model {
     @Override
     public void setStaff(Staff target, Staff editedStaff) {
         requireAllNonNull(target, editedStaff);
-
         addressBook.setStaff(target, editedStaff);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Staff> filteredStaff;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredStaff = new FilteredList<>(this.addressBook.getStaffList());
     }
 
     public ModelManager() {
@@ -144,5 +147,18 @@ public class ModelManager implements Model {
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);
     }
+
+    //=========== Filtered Staff List Accessors =============================================================
+    @Override
+    public ObservableList<Staff> getFilteredStaffList() {
+        return filteredStaff;
+    }
+
+    @Override
+    public void updateFilteredStaffList(Predicate<Staff> predicate) {
+        requireNonNull(predicate);
+        filteredStaff.setPredicate(predicate);
+    }
+
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -97,6 +97,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasStaff(Staff staff) {
+        requireNonNull(staff);
+        return addressBook.hasStaff(staff);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }
@@ -112,6 +118,23 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void deleteStaff(Staff target) {
+        addressBook.removeStaff(target);
+    }
+
+    public void addStaff(Staff staff) {
+        addressBook.addStaff(staff);
+        updateFilteredStaffList(PREDICATE_SHOW_ALL_STAFF);
+    }
+
+    @Override
+    public void setStaff(Staff target, Staff editedStaff) {
+        requireAllNonNull(target, editedStaff);
+
+        addressBook.setStaff(target, editedStaff);
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -159,6 +182,5 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredStaff.setPredicate(predicate);
     }
-
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
@@ -20,6 +22,7 @@ import seedu.address.model.person.Staff;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
+    private final ObjectProperty<ListType> currentListTypeProperty = new SimpleObjectProperty<>(ListType.PERSON);
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
@@ -153,6 +156,7 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+        setListType(ListType.PERSON);
     }
 
     @Override
@@ -182,6 +186,23 @@ public class ModelManager implements Model {
     public void updateFilteredStaffList(Predicate<Staff> predicate) {
         requireNonNull(predicate);
         filteredStaff.setPredicate(predicate);
+        setListType(ListType.STAFF);
     }
+
+    //=========== List Accessors ============================================================================
+    @Override
+    public ObjectProperty<ListType> getListTypeProperty() {
+        return currentListTypeProperty;
+    };
+
+    @Override
+    public ListType getListType() {
+        return currentListTypeProperty.get();
+    }
+
+    @Override
+    public void setListType(ListType listType) {
+        currentListTypeProperty.set(listType);
+    };
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 
 /**
  * Unmodifiable view of an address book
@@ -13,5 +14,12 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Returns an unmodifiable view of the staff list.
+     * This list will not contain any duplicate staff.
+     */
+    ObservableList<Staff> getStaffList();
+
 
 }

--- a/src/main/java/seedu/address/model/person/UniqueStaffList.java
+++ b/src/main/java/seedu/address/model/person/UniqueStaffList.java
@@ -1,0 +1,151 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+/**
+ * A list of staff that enforces uniqueness between its elements and does not allow nulls.
+ * A staff is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
+ * staff uses Person#isSamePerson(Person) for equality so as to ensure that the staff being added or updated is
+ * unique in terms of identity in the UniqueStaffList. However, the removal of a staff uses Person#equals(Object) so
+ * as to ensure that the person with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Person#isSamePerson(Person)
+ */
+public class UniqueStaffList implements Iterable<Staff> {
+
+    private final ObservableList<Staff> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Staff> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent staff as the given argument.
+     */
+    public boolean contains(Staff toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSamePerson);
+    }
+
+    /**
+     * Adds a staff to the list.
+     * The staff must not already exist in the list.
+     */
+    public void add(Staff toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicatePersonException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the staff {@code target} in the list with {@code editedStaff}.
+     * {@code target} must exist in the list.
+     * The staff identity of {@code editedStaff} must not be the same as another existing staff in the list.
+     */
+    public void setStaff(Staff target, Staff editedStaff) {
+        requireAllNonNull(target, editedStaff);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+
+        if (!target.isSamePerson(editedStaff) && contains(editedStaff)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.set(index, editedStaff);
+    }
+
+    /**
+     * Removes the equivalent staff from the list.
+     * The staff must exist in the list.
+     */
+    public void remove(Staff toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new PersonNotFoundException();
+        }
+    }
+
+    public void setStaffs(UniqueStaffList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code staff}.
+     * {@code staff} must not contain duplicate persons.
+     */
+    public void setStaffs(List<Staff> staff) {
+        requireAllNonNull(staff);
+        if (!staffAreUnique(staff)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.setAll(staff);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Staff> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Staff> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueStaffList)) {
+            return false;
+        }
+
+        UniqueStaffList otherUniqueStaffList = (UniqueStaffList) other;
+        return internalList.equals(otherUniqueStaffList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+
+    /**
+     * Returns true if {@code staff} contains only unique staff.
+     */
+    private boolean staffAreUnique(List<Staff> staff) {
+        for (int i = 0; i < staff.size() - 1; i++) {
+            for (int j = i + 1; j < staff.size(); j++) {
+                if (staff.get(i).isSamePerson(staff.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -96,6 +96,9 @@ public class MainWindow extends UiPart<Stage> {
             staffListPanel = new StaffListPanel(logic.getFilteredStaffList());
             staffListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
             break;
+
+        default:
+            return;
         }
     }
 
@@ -143,9 +146,6 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
-
-//        staffListPanel = new StaffListPanel(logic.getFilteredStaffList());
-//        staffListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -42,7 +42,7 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane listPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -111,7 +111,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ListType;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -32,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private StaffListPanel staffListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -42,7 +44,10 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane listPanelPlaceholder;
+    private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private StackPane staffListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -66,6 +71,32 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        listTypeListener();
+    }
+
+    private void listTypeListener() {
+        logic.getCurrentListTypeProperty().addListener(((observable, oldValue, newValue) -> {
+            updateListView(newValue);
+        }));
+    }
+
+    private void updateListView(ListType type) {
+        personListPanelPlaceholder.getChildren().clear();
+        staffListPanelPlaceholder.getChildren().clear();
+
+        switch (type) {
+
+        case PERSON:
+            personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+            personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+            break;
+
+        case STAFF:
+            staffListPanel = new StaffListPanel(logic.getFilteredStaffList());
+            staffListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
+            break;
+        }
     }
 
     public Stage getPrimaryStage() {
@@ -111,7 +142,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+//        staffListPanel = new StaffListPanel(logic.getFilteredStaffList());
+//        staffListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/StaffCard.java
+++ b/src/main/java/seedu/address/ui/StaffCard.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.Staff;
 /**
  * A UI component that displays information of a {@code Staff}.
  */
-public class StaffCard extends UiPart<Region>  {
+public class StaffCard extends UiPart<Region> {
 
     private static final String FXML = "StaffListCard.fxml";
 

--- a/src/main/java/seedu/address/ui/StaffCard.java
+++ b/src/main/java/seedu/address/ui/StaffCard.java
@@ -1,0 +1,72 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Staff;
+
+/**
+ * A UI component that displays information of a {@code Staff}.
+ */
+public class StaffCard extends UiPart<Region>  {
+
+    private static final String FXML = "StaffListCard.fxml";
+
+    public final Staff staff;
+
+    @FXML
+    private final Label staffLabel = new Label("Staff");
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+    @FXML
+    private Label phone;
+    @FXML
+    private Label address;
+    @FXML
+    private Label email;
+    @FXML
+    private FlowPane tags;
+    @FXML
+    private Label emergency;
+    @FXML
+    private Label block;
+    @FXML
+    private Label level;
+    @FXML
+    private Label room;
+    @FXML
+    private Label designation;
+
+    /**
+     * Creates a {@code StaffCard} with the given {@code Staff} and index to display.
+     */
+    public StaffCard(Staff staff, int displayedIndex) {
+        super(FXML);
+        this.staff = staff;
+
+        id.setText(displayedIndex + ". ");
+        name.setText(staff.getName().fullName);
+        phone.setText(staff.getPhone().value);
+        address.setText(staff.getAddress().value);
+        email.setText(staff.getEmail().value);
+        staff.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        emergency.setText(staff.getEmergency().value);
+        block.setText(staff.getBlock().value);
+        level.setText(String.valueOf(staff.getLevel().value));
+        room.setText(String.valueOf(staff.getRoom().value));
+        designation.setText(staff.getDesignation().toString());
+    }
+
+
+
+}

--- a/src/main/java/seedu/address/ui/StaffListPanel.java
+++ b/src/main/java/seedu/address/ui/StaffListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Staff;
+
+/**
+ * Panel containing the list of staff.
+ */
+public class StaffListPanel extends UiPart<Region> {
+    private static final String FXML = "StaffListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+
+    @FXML
+    private ListView<Staff> staffListView;
+
+    /**
+     * Creates a {@code StaffListPanel} with the given {@code ObservableList}.
+     */
+    public StaffListPanel(ObservableList<Staff> staffList) {
+        super(FXML);
+        staffListView.setItems(staffList);
+        staffListView.setCellFactory(listView -> new StaffListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Staff} using a {@code StaffCard}.
+     */
+    class StaffListViewCell extends ListCell<Staff> {
+        @Override
+        protected void updateItem(Staff staff, boolean empty) {
+            super.updateItem(staff, empty);
+
+            if (empty || staff == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new StaffCard(staff, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -50,7 +50,7 @@
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="listPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -53,6 +53,13 @@
           <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
+        <VBox fx:id="staffList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="staffListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox>
+
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>
     </Scene>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -50,7 +50,7 @@
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="listPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/StaffListCard.fxml
+++ b/src/main/resources/view/StaffListCard.fxml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets bottom="5" left="15" right="5" top="5" />
+            </padding>
+            <HBox alignment="CENTER_LEFT" spacing="0.5">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+            </HBox>
+         <HBox alignment="CENTER_LEFT" layoutX="25.0" layoutY="32.0" spacing="0.5">
+            <children>
+               <Label fx:id="staffLabel" minWidth="-Infinity" style="-fx-font-weight: bold; -fx-background-color: #839dc9;" text="Staff" textFill="WHITE" />
+               <Label fx:id="designation" layoutX="10.0" layoutY="10.0" minWidth="-Infinity" style="-fx-font-weight: bold; -fx-background-color: #becbeb; -fx-background-radius: 4;" text="Designation" textFill="WHITE">
+                  <HBox.margin>
+                     <Insets left="5.0" />
+                  </HBox.margin>
+               </Label>
+            </children>
+         </HBox>
+            <FlowPane fx:id="tags" />
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+         <Label fx:id="emergency" layoutX="25.0" layoutY="80.0" styleClass="cell_small_label" text="\$emergency" />
+         <HBox alignment="CENTER_LEFT" layoutX="25.0" layoutY="100.0" spacing="0.5">
+            <children>
+               <Label fx:id="block" layoutX="10.0" layoutY="10.0" minWidth="-Infinity" style="-fx-background-color: #20242e; -fx-background-radius: 4;" text="block" textFill="WHITE">
+                  <HBox.margin>
+                     <Insets />
+                  </HBox.margin>
+               </Label>
+               <Label fx:id="level" layoutX="10.0" layoutY="10.0" minWidth="-Infinity" style="-fx-background-color: #20242e; -fx-background-radius: 4;" text="level" textFill="WHITE" />
+               <Label fx:id="room" layoutX="41.0" layoutY="10.0" minWidth="-Infinity" style="-fx-background-color: #20242e; -fx-background-radius: 4;" text="room" textFill="WHITE" />
+            </children>
+         </HBox>
+        </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/StaffListPanel.fxml
+++ b/src/main/resources/view/StaffListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/main/resources/view/StaffListPanel.fxml
+++ b/src/main/resources/view/StaffListPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+    <ListView fx:id="staffListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -14,6 +15,10 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,8 +26,10 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ModelStub;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ListType;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -85,6 +92,28 @@ public class LogicManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getFilteredStaffList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredStaffList().remove(0));
+    }
+
+    @Test
+    public void listTypeListener_detectsChange() {
+        ModelStubWithChangesInCurrentListTypeProperty model = new ModelStubWithChangesInCurrentListTypeProperty();
+
+        ObjectProperty<ListType> currentListTypeProperty = logic.getCurrentListTypeProperty();
+        assertEquals(ListType.PERSON, currentListTypeProperty.get());
+
+        currentListTypeProperty.addListener(new ChangeListener<ListType>() {
+            @Override
+            public void changed(ObservableValue<? extends ListType> observable, ListType oldValue, ListType newValue) {
+                assertEquals(ListType.STAFF, newValue);
+            }
+        });
+
+        model.setListType(ListType.STAFF);
     }
 
     /**
@@ -171,5 +200,14 @@ public class LogicManagerTest {
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
+    }
+
+    private class ModelStubWithChangesInCurrentListTypeProperty extends ModelStub {
+        private final ObjectProperty<ListType> currentListTypeProperty = new SimpleObjectProperty<>(ListType.PERSON);
+
+        @Override
+        public void setListType(ListType listType) {
+            currentListTypeProperty.set(listType);
+        };
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -15,14 +14,14 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -7,21 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -82,81 +76,6 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(ALICE);
         String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
@@ -110,9 +110,9 @@ public class AddStaffCommandTest {
         }
 
         @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
+        public void addStaff(Staff staff) {
+            requireNonNull(staff);
+            personsAdded.add(staff);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
@@ -6,20 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
 import seedu.address.testutil.Assert;
@@ -82,81 +76,6 @@ public class AddStaffCommandTest {
         AddStaffCommand addCommand = new AddStaffCommand(new StaffBuilder().build());
         String expected = AddStaffCommand.class.getCanonicalName() + "{toAdd=" + new StaffBuilder().build() + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListStaffCommandTest.java
@@ -1,12 +1,11 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/ListStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListStaffCommandTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ListStaffCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListStaffCommand(), model, ListStaffCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -1,0 +1,117 @@
+package seedu.address.logic.commands;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasStaff(Staff staff) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteStaff(Staff target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addStaff(Staff staff) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setStaff(Staff target, Staff editedStaff) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Staff> getFilteredStaffList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredStaffList(Predicate<Staff> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -3,8 +3,10 @@ package seedu.address.logic.commands;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.ListType;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
@@ -112,6 +114,21 @@ public class ModelStub implements Model {
 
     @Override
     public void updateFilteredStaffList(Predicate<Staff> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObjectProperty<ListType> getListTypeProperty() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ListType getListType() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setListType(ListType listType) {
         throw new AssertionError("This method should not be called.");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListStaffCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -99,6 +100,11 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listStaff() throws Exception {
+        assertTrue(parser.parseCommand(ListStaffCommand.COMMAND_WORD) instanceof ListStaffCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.StaffBuilder;
 
 public class AddressBookTest {
 
@@ -69,6 +70,13 @@ public class AddressBookTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
         assertTrue(addressBook.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasStaff_staffInAddressBook_returnsTrue() {
+        Staff staff = new StaffBuilder().build();
+        addressBook.addStaff(staff);
+        assertTrue(addressBook.hasStaff(staff));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
 
@@ -94,6 +95,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Staff> staffs = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -102,6 +104,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Staff> getStaffList() {
+            return staffs;
         }
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Staff;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.StaffBuilder;
 
 public class ModelManagerTest {
 
@@ -89,8 +91,34 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasStaff_staffNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasStaff(new StaffBuilder().build()));
+    }
+
+    @Test
+    public void hasStaff_staffInAddressBook_returnsTrue() {
+        Staff staff = new StaffBuilder().build();
+        modelManager.addStaff(staff);
+        assertTrue(modelManager.hasStaff(staff));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getFilteredStaffList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredStaffList().remove(0));
+    }
+
+    @Test
+    public void getListType_modify_success() {
+        assertEquals(modelManager.getListType(), ListType.PERSON);
+        assertEquals(modelManager.getListTypeProperty().get(), ListType.PERSON);
+        modelManager.setListType(ListType.STAFF);
+        assertEquals(modelManager.getListType(), ListType.STAFF);
+        assertEquals(modelManager.getListTypeProperty().get(), ListType.STAFF);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniqueStaffListTest.java
+++ b/src/test/java/seedu/address/model/person/UniqueStaffListTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person;
+
+public class UniqueStaffListTest {
+}

--- a/src/test/java/seedu/address/model/person/UniqueStaffListTest.java
+++ b/src/test/java/seedu/address/model/person/UniqueStaffListTest.java
@@ -1,4 +1,157 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.StaffBuilder;
+
 public class UniqueStaffListTest {
+
+    private final UniqueStaffList uniqueStaffList = new UniqueStaffList();
+
+    @Test
+    public void contains_nullStaff_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.contains(null));
+    }
+
+    @Test
+    public void contains_staffNotInList_returnsFalse() {
+        assertFalse(uniqueStaffList.contains(new StaffBuilder().build()));
+    }
+
+    @Test
+    public void contains_staffInList_returnsTrue() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        assertTrue(uniqueStaffList.contains(staff));
+    }
+
+    @Test
+    public void contains_personWithSameIdentityFieldsInList_returnsTrue() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        Staff editedStaff = new StaffBuilder().withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+                .build();
+        assertTrue(uniqueStaffList.contains(editedStaff));
+    }
+
+    @Test
+    public void addStaff_nullStaff_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.add(null));
+    }
+
+    @Test
+    public void addStaff_duplicateStaff_throwsDuplicatePersonException() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        assertThrows(DuplicatePersonException.class, () -> uniqueStaffList.add(staff));
+    }
+
+    @Test
+    public void setStaff_nullTargetPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.setStaff(null, new StaffBuilder().build()));
+    }
+
+    @Test
+    public void setStaff_nullEditedPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.setStaff(new StaffBuilder().build(), null));
+    }
+
+    @Test
+    public void setStaff_targetPersonNotInList_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> uniqueStaffList.setStaff(
+                new StaffBuilder().build(), new StaffBuilder().build()));
+    }
+
+    @Test
+    public void setStaff_editedStaffIsSameStaff_success() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        uniqueStaffList.setStaff(staff, staff);
+        UniqueStaffList expectedUniqueStaffList = new UniqueStaffList();
+        expectedUniqueStaffList.add(staff);
+        assertEquals(expectedUniqueStaffList, uniqueStaffList);
+    }
+
+    @Test
+    public void setStaff_editedStaffHasSameIdentity_success() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        Staff editedStaff = new StaffBuilder().withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+                .build();
+        uniqueStaffList.setStaff(staff, editedStaff);
+        UniqueStaffList expectedUniqueStaffList = new UniqueStaffList();
+        expectedUniqueStaffList.add(editedStaff);
+        assertEquals(expectedUniqueStaffList, uniqueStaffList);
+    }
+
+    @Test
+    public void setStaff_editedStaffHasDifferentIdentity_success() {
+        Staff staff = new StaffBuilder().build();
+        Staff staff1 = new StaffBuilder().withName("Haikel").build();
+        uniqueStaffList.add(staff);
+        uniqueStaffList.setStaff(staff, staff1);
+        UniqueStaffList expectedUniqueStaffList = new UniqueStaffList();
+        expectedUniqueStaffList.add(staff1);
+        assertEquals(expectedUniqueStaffList, uniqueStaffList);
+    }
+
+    @Test
+    public void setStaff_editedPersonHasNonUniqueIdentity_throwsDuplicatePersonException() {
+        Staff staff = new StaffBuilder().build();
+        Staff staff1 = new StaffBuilder().withName("Haikel").build();
+        uniqueStaffList.add(staff);
+        uniqueStaffList.add(staff1);
+        assertThrows(DuplicatePersonException.class, () -> uniqueStaffList.setStaff(staff, staff1));
+    }
+
+    @Test
+    public void remove_nullStaff_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.remove(null));
+    }
+
+    @Test
+    public void remove_staffDoesNotExist_throwsPersonNotFoundException() {
+        assertThrows(PersonNotFoundException.class, () -> uniqueStaffList.remove(new StaffBuilder().build()));
+    }
+
+    @Test
+    public void remove_existingStaff_removesStaff() {
+        Staff staff = new StaffBuilder().build();
+        uniqueStaffList.add(staff);
+        uniqueStaffList.remove(staff);
+        UniqueStaffList expectedUniqueStaffList = new UniqueStaffList();
+        assertEquals(expectedUniqueStaffList, uniqueStaffList);
+    }
+
+    @Test
+    public void setStaffs_nullUniqueStaffList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.setStaffs((UniqueStaffList) null));
+    }
+
+    @Test
+    public void setPersons_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueStaffList.setStaffs((List<Staff>) null));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+                -> uniqueStaffList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void toStringMethod() {
+        assertEquals(uniqueStaffList.asUnmodifiableObservableList().toString(), uniqueStaffList.toString());
+    }
 }


### PR DESCRIPTION
We allow users to create, read, update and delete contacts, to allow the user to maintain a contact list of people, and to retrieve a contact, so that they can communicate with the person.

Our 3 types of contacts are: students, staff, and external vendors.

For the milestone v1.2, we intend to complete CRUD for staff, and external vendors.

In this PR, we will be addressing the 'R read' portion of CRUD for staff, allowing viewing of the staff list. Other portions of CRUD will be covered in subsequent PRs.