### PR TITLE
Feature 4: Search for events going on in the residences

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.event;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
-
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -35,6 +35,7 @@ public class SearchEventCommand extends Command {
     public static final String MESSAGE_NO_MATCH = "No matching events found in this list.";
     public static final String MESSAGE_NO_PARAMETERS = "Please provide at least one parameter to perform the search.";
     public static final String MESSAGE_NO_EVENTS = "There are no events in the list yet.";
+    public static final String MESSAGE_INVALID_START_END_TIME = "End time cannot be before start time.";
 
 
     private final String eventName;

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -53,7 +53,7 @@ public class SearchEventCommand extends Command {
 
     public List<Event> filterEvents(Model model) {
         return model.getFilteredEventList().stream()
-                .filter(event -> (eventName == null || event.getEventName().equals(new EventName(eventName)))
+                .filter(event -> (eventName == null || event.getEventName().toString().toLowerCase().contains(eventName.toLowerCase()))
                         && (startTime == null || !event.getEventStartTime().equals(startTime))
                         && (endTime == null || !event.getEventEndTime().equals(endTime)))
                 .collect(Collectors.toList());
@@ -73,6 +73,17 @@ public class SearchEventCommand extends Command {
             throw new CommandException(MESSAGE_NO_MATCH);
         }
 
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS + formatEventList(filteredEvents));
+    }
+
+    private String formatEventList(List<Event> eventList) {
+        StringBuilder formattedEvents = new StringBuilder();
+        for (Event event : eventList) {
+            formattedEvents.append("Event Name: ").append(event.getEventName().toString())
+                    .append(", Start Time: ").append(event.getEventStartTime().toString())
+                    .append(", End Time: ").append(event.getEventEndTime().toString())
+                    .append("\n");
+        }
+        return formattedEvents.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -1,16 +1,15 @@
 package seedu.address.logic.commands.event;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventEndTime;
-import seedu.address.model.event.EventName;
 import seedu.address.model.event.EventStartTime;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands.event;
+
+public class SearchEventCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands.event;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,8 +15,6 @@ import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventEndTime;
 import seedu.address.model.event.EventStartTime;
-
-
 
 /**
  * Searches for events in ResiConnect based on event name, start time and end time.
@@ -60,8 +58,8 @@ public class SearchEventCommand extends Command {
      */
     public List<Event> filterEvents(Model model) {
         return model.getFilteredEventList().stream()
-                .filter(event -> (eventName == null || event.getEventName().toString().
-                        toLowerCase().contains(eventName.toLowerCase()))
+                .filter(event -> (eventName == null || event.getEventName().toString()
+                        .toLowerCase().contains(eventName.toLowerCase()))
                         && (startTime == null || !event.getEventStartTime().equals(startTime))
                         && (endTime == null || !event.getEventEndTime().equals(endTime)))
                 .collect(Collectors.toList());

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -1,8 +1,9 @@
 package seedu.address.logic.commands.event;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -1,4 +1,77 @@
 package seedu.address.logic.commands.event;
 
-public class SearchEventCommand {
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventEndTime;
+import seedu.address.model.event.EventName;
+import seedu.address.model.event.EventStartTime;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+
+/**
+ * Searches for events in ResiConnect based on event name, start time and end time.
+ */
+public class SearchEventCommand extends Command {
+    public static final String COMMAND_WORD = "search_event";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Searches for events in ResiConnect. "
+            + "Parameters: "
+            + PREFIX_EVENT_NAME + "EVENT_NAME "
+            + PREFIX_EVENT_START_TIME + "START_TIME (yyyy-MM-dd HH:mm) "
+            + PREFIX_EVENT_END_TIME + "END_TIME (yyyy-MM-dd HH:mm) \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_EVENT_NAME + "Dance Club Rehearsal ";
+
+    public static final String MESSAGE_SUCCESS = "Matching events found in this list: ";
+    public static final String MESSAGE_NO_MATCH = "No matching events found in this list.";
+    public static final String MESSAGE_NO_PARAMETERS = "Please provide at least one parameter to perform the search.";
+    public static final String MESSAGE_NO_EVENTS = "There are no events in the list yet.";
+
+
+    private final String eventName;
+    private final EventStartTime startTime;
+    private final EventEndTime endTime;
+
+    /**
+     * Creates a SearchEventCommand to search for events with the specified parameters.
+     */
+    public SearchEventCommand(String eventName, EventStartTime startTime, EventEndTime endTime) {
+        this.eventName = eventName;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public List<Event> filterEvents(Model model) {
+        return model.getFilteredEventList().stream()
+                .filter(event -> (eventName == null || event.getEventName().equals(new EventName(eventName)))
+                        && (startTime == null || !event.getEventStartTime().equals(startTime))
+                        && (endTime == null || !event.getEventEndTime().equals(endTime)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.getFilteredEventList().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_EVENTS);
+        }
+
+        List<Event> filteredEvents = filterEvents(model);
+
+        if (filteredEvents.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_MATCH);
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/SearchEventCommand.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.commands.event;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -11,10 +16,7 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventEndTime;
 import seedu.address.model.event.EventStartTime;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+
 
 /**
  * Searches for events in ResiConnect based on event name, start time and end time.
@@ -50,9 +52,16 @@ public class SearchEventCommand extends Command {
         this.endTime = endTime;
     }
 
+    /**
+     * Filters events based on the provided parameters.
+     *
+     * @param model The model containing the list of events.
+     * @return A list of events that match the search criteria.
+     */
     public List<Event> filterEvents(Model model) {
         return model.getFilteredEventList().stream()
-                .filter(event -> (eventName == null || event.getEventName().toString().toLowerCase().contains(eventName.toLowerCase()))
+                .filter(event -> (eventName == null || event.getEventName().toString().
+                        toLowerCase().contains(eventName.toLowerCase()))
                         && (startTime == null || !event.getEventStartTime().equals(startTime))
                         && (endTime == null || !event.getEventEndTime().equals(endTime)))
                 .collect(Collectors.toList());

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -106,10 +106,10 @@ public class AddressBookParser {
 
         case ListStaffCommand.COMMAND_WORD:
             return new ListStaffCommand();
-            
+
         case SearchEventCommand.COMMAND_WORD:
             return new SearchEventCommandParser().parse(arguments);
-            
+
         case SearchStaffCommand.COMMAND_WORD:
             return new SearchStaffCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.ListStaffCommand;
 import seedu.address.logic.commands.event.AddEventCommand;
 import seedu.address.logic.commands.event.DeleteEventCommand;
 import seedu.address.logic.commands.event.ListEventCommand;
+import seedu.address.logic.commands.event.SearchEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case ListStaffCommand.COMMAND_WORD:
             return new ListStaffCommand();
+
+        case SearchEventCommand.COMMAND_WORD:
+            return new SearchEventCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
@@ -5,13 +5,10 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.Optional;
 
 import seedu.address.logic.commands.event.SearchEventCommand;
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
 
-import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.EventEndTime;
 import seedu.address.model.event.EventStartTime;

--- a/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Optional;
+
+import seedu.address.logic.commands.event.SearchEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.EventEndTime;
+import seedu.address.model.event.EventStartTime;
+
+/**
+ * Parses input arguments and creates a SearchEventCommand object.
+ */
+public class SearchEventCommandParser implements Parser<SearchEventCommand> {
+
+    @Override
+    public SearchEventCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_EVENT_NAME,
+                PREFIX_EVENT_START_TIME, PREFIX_EVENT_END_TIME);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchEventCommand.MESSAGE_USAGE));
+        }
+
+        Optional<String> eventName = argMultimap.getValue(CliSyntax.PREFIX_EVENT_NAME);
+        Optional<String> startTimeStr = argMultimap.getValue(CliSyntax.PREFIX_EVENT_START_TIME);
+        Optional<String> endTimeStr = argMultimap.getValue(CliSyntax.PREFIX_EVENT_END_TIME);
+
+        if (eventName.isEmpty() && startTimeStr.isEmpty() && endTimeStr.isEmpty()) {
+            throw new ParseException(SearchEventCommand.MESSAGE_NO_PARAMETERS);
+        }
+
+        EventStartTime startTime = startTimeStr.map(EventStartTime::new).orElse(null);
+        EventEndTime endTime = endTimeStr.map(EventEndTime::new).orElse(null);
+
+        if (startTime != null && endTime != null && endTime.endTime.isBefore(startTime.startTime)) {
+            throw new ParseException(SearchEventCommand.MESSAGE_INVALID_START_END_TIME);
+        }
+
+        return new SearchEventCommand(eventName.orElse(null), startTime, endTime);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 
 import java.util.Optional;

--- a/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
@@ -1,14 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
-import java.util.Optional;
-
-import seedu.address.logic.commands.event.SearchEventCommand;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
 
+import java.util.Optional;
+
+import seedu.address.logic.commands.event.SearchEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.EventEndTime;
 import seedu.address.model.event.EventStartTime;

--- a/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchEventCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_START_TIME;
 
 import java.util.Optional;
 

--- a/src/main/java/seedu/address/model/event/EventStartTime.java
+++ b/src/main/java/seedu/address/model/event/EventStartTime.java
@@ -71,6 +71,4 @@ public class EventStartTime {
     public boolean isBefore(EventEndTime endTime) {
         return this.startTime.isBefore(endTime.endTime);
     }
-
-
 }


### PR DESCRIPTION
Key changes:
- Implemented search_event n/NAME [s/START_TIME] [e/END_TIME] command
- Allows case-insensitive partial word matching for event names (e.g. n/meet matches "Team Meeting")
- Supports prefix searching for:
    - Event names (substring match)
    - Start times (exact prefix match)
    - End times (exact prefix match)
- Displays results in command palette as formatted strings

Future improvements:
- Show search result in ListEventPane for better visualization
- Add additional search prefixes matching add_event parameters
- Implement fuzzy search for time formats
- Add more test cases