### PR TITLE
Features 1 and 3: Integration for Deletion of Staff

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -212,6 +212,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeStaff(Staff key) {
         this.staff.remove(key);
+        this.events.removeFromAllEvents(key);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -149,7 +149,12 @@ public class Event {
     }
 
 
-
+    /**
+     * Returns true if the {@code staff} is part in this event's staff list.
+     */
+    public boolean isStaffInEvent(Staff staff) {
+        return staffs.contains(staff);
+    }
 
 
     @Override

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.event.exceptions.EventNotFoundException;
+import seedu.address.model.person.Staff;
 
 /**
  * A list that maintains unique events and does not allow duplicates.
@@ -72,6 +73,19 @@ public class UniqueEventList implements Iterable<Event> {
         requireNonNull(toRemove);
         if (!internalList.remove(toRemove)) {
             throw new EventNotFoundException();
+        }
+    }
+
+    /**
+     * Removes the staff from all events stored in this UniqueEventList. Call for this function should only
+     * originate from a DeleteStaffCommand.
+     *
+     */
+    public void removeFromAllEvents(Staff staff) {
+        for (Event e : internalList) {
+            if (e.isStaffInEvent(staff)) {
+                e.removeStaff(staff);
+            }
         }
     }
 

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -1,9 +1,13 @@
 package seedu.address.model.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import seedu.address.model.person.Staff;
+import seedu.address.testutil.TypicalStaffs;
 
 public class EventTest {
 
@@ -111,6 +115,16 @@ public class EventTest {
         Event event2 = new Event(new EventName("Concert"), new EventStartTime("2025-07-01 18:00"),
                 new EventEndTime("2025-07-01 22:00"));
         assertEquals(event1.hashCode(), event2.hashCode());
+    }
+
+    @Test
+    public void isStaffInEvent_correct() {
+        Event event = new Event(new EventName("Concert"), new EventStartTime("2025-07-01 18:00"),
+                new EventEndTime("2025-07-01 22:00"));
+        Staff staff = TypicalStaffs.HARIS;
+        assertFalse(event.isStaffInEvent(staff));
+        event.addStaff(staff);
+        assertTrue(event.isStaffInEvent(staff));
     }
 
 

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.person.Staff;
 import seedu.address.testutil.TypicalStaffs;
 
@@ -126,21 +127,5 @@ public class EventTest {
         event.addStaff(staff);
         assertTrue(event.isStaffInEvent(staff));
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 }

--- a/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
@@ -2,7 +2,6 @@ package seedu.address.model.event;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static seedu.address.testutil.TypicalEvents.DANCE_EVENT;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalStaffs.HARIS;
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.AddressBook;
 
 public class UniqueEventListIntegrationTest {
-    AddressBook addressBook;
+    private AddressBook addressBook;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.event;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static seedu.address.testutil.TypicalEvents.DANCE_EVENT;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalStaffs.HARIS;

--- a/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListIntegrationTest.java
@@ -1,0 +1,33 @@
+package seedu.address.model.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalEvents.DANCE_EVENT;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalStaffs.HARIS;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+
+public class UniqueEventListIntegrationTest {
+    AddressBook addressBook;
+
+    @BeforeEach
+    public void setup() {
+        addressBook = getTypicalAddressBook();
+    }
+
+    @Test
+    public void removeFromAllEvents_staff_correct() {
+        Event event = DANCE_EVENT;
+
+        assertTrue(addressBook.hasStaff(HARIS));
+        event.addStaff(HARIS);
+        addressBook.addEvent(event);
+        addressBook.removeStaff(HARIS);
+
+        assertFalse(event.isStaffInEvent(HARIS));
+    }
+}


### PR DESCRIPTION
Currently, when a staff is deleted from ResiConnect, their data may still remain in the events list. In this issue, we will be looking to ensure that an deletion of staff is cascaded correctly.