### PR TITLE
fix UI listing problem

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -48,25 +48,13 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane staffListPanelPlaceholder;
-
-    @FXML
-    private StackPane externalPartyListPanelPlaceholder;
-
-    @FXML
-    private StackPane studentListPanelPlaceholder;
-
-    @FXML
-    private StackPane eventListPanelPlaceholder;
-
-    @FXML
     private StackPane resultDisplayPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
 
     @FXML
-    private StackPane eventDetailPanelPlaceholder;
+    private StackPane mainListPanelPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -95,41 +83,28 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     private void updateListView(ListType type) {
-        eventListPanel = null;
-        eventDetailPanel = null;
-        staffListPanel = null;
-        studentListPanel = null;
-        staffListPanelPlaceholder.getChildren().clear();
-        externalPartyListPanelPlaceholder.getChildren().clear();
-        studentListPanelPlaceholder.getChildren().clear();
-        eventListPanelPlaceholder.getChildren().clear();
-        eventDetailPanelPlaceholder.getChildren().clear();
+        mainListPanelPlaceholder.getChildren().clear();
 
         switch (type) {
-
         case STAFF:
             staffListPanel = new StaffListPanel(logic.getFilteredStaffList());
-            staffListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
+            mainListPanelPlaceholder.getChildren().add(staffListPanel.getRoot());
             break;
-
         case EXTERNAL:
             externalPartyListPanel = new ExternalPartyListPanel(logic.getFilteredExternalPartyList());
-            externalPartyListPanelPlaceholder.getChildren().add(externalPartyListPanel.getRoot());
+            mainListPanelPlaceholder.getChildren().add(externalPartyListPanel.getRoot());
             break;
-
         case STUDENT:
             studentListPanel = new StudentListPanel(logic.getFilteredStudentList());
-            studentListPanelPlaceholder.getChildren().add(studentListPanel.getRoot());
+            mainListPanelPlaceholder.getChildren().add(studentListPanel.getRoot());
             break;
-
         case EVENT:
             eventListPanel = new EventListPanel(logic.getFilteredEventList());
-            eventListPanelPlaceholder.getChildren().add(eventListPanel.getRoot());
+            mainListPanelPlaceholder.getChildren().add(eventListPanel.getRoot());
             break;
-
         case EVENTDETAIL:
             eventDetailPanel = new EventDetailPanel(logic.getSelectedEventDetail(), logic.getSelectedEventIndex());
-            eventDetailPanelPlaceholder.getChildren().add(eventDetailPanel.getRoot());
+            mainListPanelPlaceholder.getChildren().add(eventDetailPanel.getRoot());
             break;
 
         default:
@@ -179,8 +154,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        studentListPanel = new StudentListPanel(logic.getFilteredStudentList());
-        studentListPanelPlaceholder.getChildren().add(studentListPanel.getRoot());
+        updateListView(ListType.STUDENT); // Display student list by default when app starts
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -44,40 +44,13 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="studentList" minHeight="0.0" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+        <VBox fx:id="mainList" minHeight="0.0" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
           <padding>
             <Insets bottom="10" left="10" right="10" top="10" />
           </padding>
-          <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+          <StackPane fx:id="mainListPanelPlaceholder" VBox.vgrow="ALWAYS" />
         </VBox>
 
-        <VBox fx:id="staffList" minHeight="0.0" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets bottom="10" left="10" right="10" top="10" />
-          </padding>
-          <StackPane fx:id="staffListPanelPlaceholder" minHeight="0.0" VBox.vgrow="ALWAYS" />
-        </VBox>
-
-        <VBox fx:id="externalPartyList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="externalPartyListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
-
-        <VBox fx:id="eventList" minHeight="0.0" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets bottom="10" left="10" right="10" top="10" />
-          </padding>
-          <StackPane fx:id="eventListPanelPlaceholder" minHeight="0.0" VBox.vgrow="ALWAYS" />
-        </VBox>
-
-        <VBox fx:id="eventDetailPanelContainer" minHeight="100" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="NEVER">
-          <padding>
-            <Insets bottom="10" left="10" right="10" top="10" />
-          </padding>
-          <StackPane fx:id="eventDetailPanelPlaceholder" minHeight="100" VBox.vgrow="NEVER" />
-        </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" minHeight="0.0" VBox.vgrow="NEVER" />
       </VBox>


### PR DESCRIPTION
I have changed the multiple list placeholders in MainWindow.fxml into a single mainListPanelPlaceholder. This change ensures that only the relevant list panel is displayed when switching between lists, preventing extra empty boxes from appearing at the top of the UI.