### PR TITLE
bug fix - person name that include exceptions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -511,7 +511,8 @@ Here is a comprehensive list for any constraints that we have specified above!
 * Event Name `name/`: Event names should only contain alphanumeric characters and spaces, and it should not be blank. Do note if you input more than 1 whitespace in the middle of the name, it will be shortened down to just 1 whitespace.
 * Level `level/`: Levels should only be positive integers up to 99, and it should not be blank. Note that any input with leading "0"s will be trimmed and treated as if there were no leading "0"s.
 * Matric `matric/`: Matric numbers should start with 'A', followed by 7 numeric digits, and end with a letter.
-* Name `name/`: Names should only contain alphanumeric characters and spaces, and it should not be blank. Do note if you input more than 1 whitespace in the middle of the name, it will be shortened down to just 1 whitespace.
+* Name `name/`: Names should only contain alphanumeric characters, spaces, and some exceptions, and should not be blank. Allowed exceptions: names may include multiple '-' characters, and exactly one of 's/o', 'd/o', or '@'.
+  These exceptions must not appear at the start or end of the name. Do note if you input more than 1 whitespace in the middle of the name, it will be shortened down to just 1 whitespace.
 * Phone `phone/`: Phone numbers should only contain numbers, and it should be at least 3 digits long.
 * Room `room/`: Rooms should only be positive integers up to 99, and it should not be blank. Note that any input with leading "0"s will be trimmed and treated as if there were no leading "0"s.
 * StaffDesignation `designation/`: Designation should only be an integer from 0 to 2, and it should not be blank. 0 to 2 represent Support Staff, Block IC and Residence Master respectively.

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,25 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters, spaces, and some exceptions, and must not be blank.\n"
+                    + "Allowed exceptions: names may include multiple '-' characters, and exactly one of "
+                    + "'s/o', 'd/o', or '@'.\n"
+                    + "These exceptions must not appear at the start or end of the name.";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Validates names with the following rules:
+     * - Must start and end with an alphanumeric character.
+     * - Can contain alphanumerics, spaces, and hyphens.
+     * - May include exactly one of the following: 's/o', 'd/o', or '@<alphanumeric>'.
+     * - These special tokens must not appear at the start or end of the name.
+     * - Multiple hyphens are allowed.
+     * - 's/o' and 'd/o' must appear with spaces before and after.
+     * - The name must not be blank.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX =
+            "^(?!.*\\b(s/o|d/o)\\b.*\\b(s/o|d/o)\\b)(?!.*@.*@)[\\p{Alnum}](?:[\\p{Alnum} \\-]*?"
+                    + "(?: s/o | d/o |@[\\p{Alnum}]+)?[\\p{Alnum} \\-]*)[\\p{Alnum}]$";
+
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -18,8 +18,8 @@ public class Name {
     /*
      * Validates names with the following rules:
      * - Must start and end with an alphanumeric character.
-     * - Can contain alphanumerics, spaces, and hyphens.
-     * - May include exactly one of the following: 's/o', 'd/o', or '@<alphanumeric>'.
+     * - Can contain alphanumerics, spaces, and hyphens '-'.
+     * - May include exactly one of the following: 's/o', 'd/o', or '@'.
      * - These special tokens must not appear at the start or end of the name.
      * - Multiple hyphens are allowed.
      * - 's/o' and 'd/o' must appear with spaces before and after.

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,7 +21,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R#chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -39,6 +39,36 @@ public class NameTest {
     }
 
     @Test
+    public void isValidName_withExceptions() {
+
+        assertTrue(Name.isValidName("John s/o Mark")); // valid use of 's/o' in the middle
+        assertTrue(Name.isValidName("Mary d/o Jane")); // valid use of 'd/o' in the middle
+        assertTrue(Name.isValidName("alex-james")); // multiple hyphens
+        assertTrue(Name.isValidName("peter@home")); // one @, not at start or end
+        assertTrue(Name.isValidName("Jean-Luc s/o Kevin")); // alphanumerics, hyphen, and s/o
+        assertTrue(Name.isValidName("Anna-Marie d/o Tan")); // hyphen + d/o
+        assertTrue(Name.isValidName("A--B--C")); // multiple hyphens between alphanumerics
+
+
+        assertFalse(Name.isValidName("@peter")); // starts with '@'
+        assertFalse(Name.isValidName("john@")); // ends with '@'
+        assertFalse(Name.isValidName("s/o Mark")); // starts with 's/o'
+        assertFalse(Name.isValidName("John s/o")); // ends with 's/o'
+        assertFalse(Name.isValidName("John s/o Mark d/o Jane")); // two special phrases
+        assertFalse(Name.isValidName("amy@@home")); // multiple '@'
+        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric symbol '*'
+        assertFalse(Name.isValidName("-peter")); // starts with '-'
+        assertFalse(Name.isValidName("peter-")); // ends with '-'
+        assertFalse(Name.isValidName("@")); // only special char
+        assertFalse(Name.isValidName("s/o")); // only special phrase
+        assertFalse(Name.isValidName("-")); // only hyphen
+        assertFalse(Name.isValidName("--")); // only hyphens
+        assertFalse(Name.isValidName(" - ")); // only space and hyphen
+    }
+
+
+
+    @Test
     public void equals() {
         Name name = new Name("Valid Name");
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedExternalPartyTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedExternalPartyTest.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedExternalPartyTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R#chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_DESCRIPTION = " invalid description";

--- a/src/test/java/seedu/address/storage/JsonAdaptedStaffTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStaffTest.java
@@ -22,7 +22,7 @@ import seedu.address.model.person.Room;
 import seedu.address.model.person.StaffDesignation;
 
 public class JsonAdaptedStaffTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Rachel s/o ";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -23,7 +23,7 @@ import seedu.address.model.person.Room;
 import seedu.address.model.person.StudentDesignation;
 
 public class JsonAdaptedStudentTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Rachel-";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";


### PR DESCRIPTION
Names should only contain alphanumeric characters, spaces, and some exceptions, and must not be blank. 
Allowed exceptions: names may include multiple '-' characters, and exactly one of 's/o', 'd/o', or '@'. 
These exceptions must not appear at the start or end of the name.
    